### PR TITLE
Some linux fixes

### DIFF
--- a/assets/requirements/requirements.txt
+++ b/assets/requirements/requirements.txt
@@ -34,7 +34,7 @@ opencv_python_headless==4.8.0.74
 pandas==2.0.3
 praat-parselmouth==0.4.2
 PySimpleGUI==4.60.5
-pyworld==0.3.3
+pyworld==0.3.4
 requests==2.31.0
 resampy==0.4.2
 scikit_learn==1.3.0

--- a/infer-web.py
+++ b/infer-web.py
@@ -173,42 +173,17 @@ isinterrupted = 0
 if torch.cuda.is_available() or ngpu != 0:
     for i in range(ngpu):
         gpu_name = torch.cuda.get_device_name(i)
-        if any(
-            value in gpu_name.upper()
-            for value in [
-                "10",
-                "16",
-                "20",
-                "30",
-                "40",
-                "A2",
-                "A3",
-                "A4",
-                "P4",
-                "A50",
-                "500",
-                "A60",
-                "70",
-                "80",
-                "90",
-                "M4",
-                "T4",
-                "TITAN",
-            ]
-        ):
-            # A10#A100#V100#A40#P40#M40#K80#A4500
-            if_gpu_ok = True  # 至少有一张能用的N卡
-            gpu_infos.append("%s\t%s" % (i, gpu_name))
-            mem.append(
-                int(
-                    torch.cuda.get_device_properties(i).total_memory
-                    / 1024
-                    / 1024
-                    / 1024
-                    + 0.4
-                )
+        gpu_infos.append("%s\t%s" % (i, gpu_name))
+        mem.append(
+            int(
+                torch.cuda.get_device_properties(i).total_memory
+                / 1024
+                / 1024
+                / 1024
+                + 0.4
             )
-if if_gpu_ok and len(gpu_infos) > 0:
+        )
+if len(gpu_infos) > 0:
     gpu_info = "\n".join(gpu_infos)
     default_batch_size = min(mem) // 2
 else:

--- a/lib/tools/model_fetcher.py
+++ b/lib/tools/model_fetcher.py
@@ -72,7 +72,7 @@ if not os.path.exists("torchcrepe"):
 
     # Removing the temporary directory
     print("Removing the temporary directory...")
-    subprocess.run("rmdir /s /q temp_torchcrepe", shell=True)
+    shutil.rmtree("temp_torchcrepe")
 
 # Download files that do not exist
 for remote_folder, file_list in models_download:


### PR DESCRIPTION
- Bumps pyworld to 0.3.4 to avoid compilation issues on most linux systems (0.3.3 requires manual steps to get working, 0.3.4 works as is)
- Remove some questionable code that filters out the supported GPU display on the training page. If a GPU is deemed as unsupported, it just didn't list it, even though that GPU could very well be used (e.g. AMD cards on the ROCm pytorch build)
- Replaces a questionable `rmdir` call that attempted to remove /s and /q on linux, since rmdir doesn't treat those as flags. 

For the GPU training display, one downside is that we're now also displaying cards that aren't quite supported (e.g. GTX 9xx cards and older). Not sure on how to deal with it properly, I don't think the torch API allows to test a device cleanly.

Unrelated, but is the makefile still relevant ? It doesn't download pretrains to the right place 