### PR TITLE
Fix go-tensorboard.sh calling python3.9 insted of just python

### DIFF
--- a/go-tensorboard.sh
+++ b/go-tensorboard.sh
@@ -7,7 +7,7 @@ echo "Starting the Tensorboard with Conda..."
 clear
 echo "Starting Tensorboard..."
 pip install tensorboard
-python3.9 lib/fixes/tensor-launch.py
+python lib/fixes/tensor-launch.py
 
 read -p "Press Enter to exit..."
 exit 0


### PR DESCRIPTION
## So a little bit of documentation about this for later changes.
#### This was made because i found some bad uses of python venv in my previous prs 

First. the installer is going to creacte a virtual env for python. like in conda.
This will pass PEP 668 in later versions of linux (3.9+) or common known has pip don't installing dependencies.
Is like the node_modules but for python

The venv create .venv where the python version where we get
`activate  activate.csh  activate.fish  Activate.ps1  pip  pip3  pip3.11  python  python3  python3.11`

Activate is to activate the venv. and has you can see python always is going to have 3 names here  python  python3  python3.11.
If we only use python(version here) this will break the compat for other python versions.

#### Conclussion
The code should always refer to python as `python` or `python3`.

This may ocassion a question
¿Then why is $py used in the installer?. In some distros or systems python for some reason isn't called python3 and is just called python. $py let the installer to search what is the binary of python3 and use it for create the venv. after that you can refer python as python or python3. (This also applies to windows if you add python - m venv .venv and the windows eq of source .venv/bin/activate)

#### Resources 
https://peps.python.org/pep-0668/
https://docs.python.org/3/library/venv.html
https://github.com/IAHispano/Applio-RVC-Fork/blob/main/install_Applio.sh
https://stackoverflow.com/questions/60679784/usr-bin-python3-bad-interpreter-how-to-make-python3-work-again and similar issues