### PR TITLE
Update go-applio-manager.bat for PyTorch 2.1

### DIFF
--- a/go-applio-manager.bat
+++ b/go-applio-manager.bat
@@ -168,7 +168,7 @@ call "%CONDA_ROOT_PREFIX%\condabin\conda.bat" activate "%INSTALL_ENV_DIR%"
 pip install -r %principal%\assets\requirements\requirements.txt
 pip install future==0.18.2
 pip uninstall torch torchvision torchaudio -y
-pip install torch==2.0.0 torchvision==0.15.1 torchaudio==2.0.1 --index-url https://download.pytorch.org/whl/cu117
+pip install torch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1 --index-url https://download.pytorch.org/whl/cu121
 goto reinstallFinished
 )
 
@@ -221,7 +221,7 @@ pip install -r assets/requirements/requirements.txt
 echo.
 pip uninstall torch torchvision torchaudio -y
 echo.
-pip install torch==2.0.0 torchvision==0.15.1 torchaudio==2.0.1 --index-url https://download.pytorch.org/whl/cu117
+pip install torch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1 --index-url https://download.pytorch.org/whl/cu121
 echo.
 echo.
 cls
@@ -363,7 +363,7 @@ pip install -r assets/requirements/requirements.txt
 echo.
 pip uninstall torch torchvision torchaudio -y
 echo.
-pip install torch==2.0.0 torchvision==0.15.1 torchaudio==2.0.1 --index-url https://download.pytorch.org/whl/cu117
+pip install torch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1 --index-url https://download.pytorch.org/whl/cu121
 echo.
 echo.
 cls
@@ -456,7 +456,7 @@ call "%CONDA_ROOT_PREFIX%\condabin\conda.bat" activate "%INSTALL_ENV_DIR%"
 pip install -r %principal%\assets\requirements\requirements.txt
 pip install future==0.18.2
 pip uninstall torch torchvision torchaudio -y
-pip install torch==2.0.0 torchvision==0.15.1 torchaudio==2.0.1 --index-url https://download.pytorch.org/whl/cu117
+pip install torch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1 --index-url https://download.pytorch.org/whl/cu121
 cls
 echo Conda env downloaded!
 echo.


### PR DESCRIPTION
An error was being thrown on the windows launch due to PyTorch not being the version required.  It required 2.1.